### PR TITLE
Fixes chip-certification-tool#649

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
@@ -232,8 +232,8 @@ tests:
       attribute: "CurrentHue"
       response:
           constraints:
-              minValue: 8
-              maxValue: 12
+              minValue: 2
+              maxValue: 18
 
     - label: "Wait 10s"
       PICS: CC.S.F00


### PR DESCRIPTION
Expanded accepted criteria for Color Control Test Case 3.2, step 3c to hue 2-18. This test case utilizes the MoveHue command, so hue value is changing over time. If the Test Harness takes longer than 400ms to send the command then the step will fail as the hue has already changed outside of the accepted criteria. Expanding the accepted criteria adds more tolerance and should improve reliability of the test.

